### PR TITLE
Add light/dark theme toggle and UI refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en-NZ">
+<html lang="en-NZ" data-theme="auto">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -17,7 +17,10 @@
     <a href="#main-content" class="skip-link">Skip to content</a>
     <div id="app">
       <header>
-        <h1>Daylog</h1>
+        <div class="header-row">
+          <h1>Daylog</h1>
+          <button class="theme-toggle" id="theme-toggle" type="button"></button>
+        </div>
         <nav id="main-nav" aria-label="Main">
           <button data-view="log" class="nav-btn active" aria-current="page">
             Log

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "htm": "3.1.1",
-        "idb": "8.0.3"
+        "idb": "8.0.3",
+        "open-props": "^1.7.23"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -5771,6 +5772,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/open-props": {
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/open-props/-/open-props-1.7.23.tgz",
+      "integrity": "sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "htm": "3.1.1",
-    "idb": "8.0.3"
+    "idb": "8.0.3",
+    "open-props": "^1.7.23"
   },
   "overrides": {
     "serialize-javascript": "7.0.4"

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,6 +8,7 @@ import type {
   EncryptedEnvelope,
   EncryptionMeta,
   FailedAttempts,
+  ThemePreference,
 } from './types'
 
 const DB_NAME = 'daylog'
@@ -162,6 +163,22 @@ export const atomicRekey = async (
     await metaStore.put({ key: 'encryption', ...meta })
   }
   await tx.done
+}
+
+// ---------- Theme preference ----------
+
+export const getThemePreference = async (): Promise<ThemePreference> => {
+  const db = await getDb()
+  const result = await db.get('meta', 'theme')
+  if (!result) return 'auto'
+  return (result as unknown as { mode: ThemePreference }).mode
+}
+
+export const setThemePreference = async (
+  mode: ThemePreference,
+): Promise<void> => {
+  const db = await getDb()
+  await db.put('meta', { key: 'theme', mode })
 }
 
 // ---------- Full wipe ----------

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 import type { AttendanceEntry } from './types'
 import { isEncryptionEnabled, isUnlocked } from './crypto'
 import { startAutoLock, resetAutoLock } from './autolock'
+import { initTheme, initThemeToggle } from './theme'
 import { renderLogView } from './ui/log'
 import { renderHistoryView } from './ui/history'
 import { renderSettingsView } from './ui/settings'
@@ -74,4 +75,8 @@ navButtons.forEach((btn) => {
 })
 
 startAutoLock(() => navigateTo(currentView))
-navigateTo(currentView)
+
+// Initialise theme before first render to avoid flash of wrong colours.
+const themeToggle = document.getElementById('theme-toggle') as HTMLButtonElement
+initThemeToggle(themeToggle)
+initTheme().then(() => navigateTo(currentView))

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 // Mediator between the UI and settings storage.
 // UI code imports this instead of db.ts directly.
 
-import type { AttendanceSettings } from './types'
+import type { AttendanceSettings, ThemePreference } from './types'
 import * as db from './db'
 
 export const loadAttendanceSettings = async (): Promise<AttendanceSettings> =>
@@ -11,4 +11,13 @@ export const saveAttendanceSettings = async (
   settings: AttendanceSettings,
 ): Promise<void> => {
   await db.setAttendanceSettings(settings)
+}
+
+export const loadThemePreference = async (): Promise<ThemePreference> =>
+  db.getThemePreference()
+
+export const saveThemePreference = async (
+  mode: ThemePreference,
+): Promise<void> => {
+  await db.setThemePreference(mode)
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,7 @@
-/* Daylog styles. Minimal, system-font, dark theme. */
+/* Daylog styles. System-font, light/dark adaptive theme. */
+
+@import 'open-props/shadows.min.css';
+@import 'open-props/easings.min.css';
 
 *,
 *::before,
@@ -8,19 +11,94 @@
   padding: 0;
 }
 
+/* ---- Light palette (default) ---- */
 :root {
+  color-scheme: light dark;
+
+  --accent: #c0274a;
+  --accent-bg: #b02544;
+  --accent-bg-hover: #cf2e52;
+  --bg: #f4f5f7;
+  --bg-input: #e8eaed;
+  --bg-surface: #ffffff;
+  --border: rgba(0, 0, 0, 0.1);
+  --danger: #c0392b;
+  --danger-hover: #e74c3c;
+  --gap: 1rem;
+  --radius: 8px;
+  --success: #1a7f4b;
+  --text: #1a1a2e;
+  --text-muted: #5a5a6e;
+  --warning: #b8860b;
+
+  --badge-office: #2d6a4f;
+  --badge-office-bg: #d4edda;
+  --badge-wfh: #1d4e89;
+  --badge-wfh-bg: #d0e0f0;
+  --badge-leave: #7b2d8b;
+  --badge-leave-bg: #e8d5f0;
+  --badge-sick: #9a5218;
+  --badge-sick-bg: #f0e0d0;
+  --badge-holiday: #555e68;
+  --badge-holiday-bg: #e0e2e5;
+}
+
+/* ---- Dark palette ---- */
+[data-theme='dark'] {
   --accent: #e94560;
   --accent-bg: #bf3048;
   --accent-bg-hover: #d43d57;
   --bg: #1a1a2e;
   --bg-input: #0f3460;
   --bg-surface: #16213e;
+  --border: rgba(255, 255, 255, 0.1);
   --danger: #c0392b;
   --danger-hover: #e74c3c;
-  --gap: 1rem;
-  --radius: 8px;
+  --success: #4caf7c;
   --text: #e0e0e0;
   --text-muted: #a0a0b0;
+  --warning: #e6a23c;
+
+  --badge-office: #fff;
+  --badge-office-bg: #2d6a4f;
+  --badge-wfh: #fff;
+  --badge-wfh-bg: #1d4e89;
+  --badge-leave: #fff;
+  --badge-leave-bg: #7b2d8b;
+  --badge-sick: #fff;
+  --badge-sick-bg: #9a5218;
+  --badge-holiday: #fff;
+  --badge-holiday-bg: #6c757d;
+}
+
+/* Auto: follow OS preference */
+@media (prefers-color-scheme: dark) {
+  [data-theme='auto'] {
+    --accent: #e94560;
+    --accent-bg: #bf3048;
+    --accent-bg-hover: #d43d57;
+    --bg: #1a1a2e;
+    --bg-input: #0f3460;
+    --bg-surface: #16213e;
+    --border: rgba(255, 255, 255, 0.1);
+    --danger: #c0392b;
+    --danger-hover: #e74c3c;
+    --success: #4caf7c;
+    --text: #e0e0e0;
+    --text-muted: #a0a0b0;
+    --warning: #e6a23c;
+
+    --badge-office: #fff;
+    --badge-office-bg: #2d6a4f;
+    --badge-wfh: #fff;
+    --badge-wfh-bg: #1d4e89;
+    --badge-leave: #fff;
+    --badge-leave-bg: #7b2d8b;
+    --badge-sick: #fff;
+    --badge-sick-bg: #9a5218;
+    --badge-holiday: #fff;
+    --badge-holiday-bg: #6c757d;
+  }
 }
 
 html {
@@ -39,8 +117,12 @@ body {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
     sans-serif;
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   min-height: 100dvh;
+  transition:
+    background-color 0.2s var(--ease-out-2),
+    color 0.2s var(--ease-out-2);
 }
 
 #app {
@@ -58,10 +140,38 @@ header {
   margin-bottom: 1.5rem;
 }
 
+.header-row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
 header h1 {
   font-size: 1.5rem;
   font-weight: 700;
   letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.theme-toggle {
+  align-items: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  min-height: 36px;
+  min-width: 36px;
+  padding: 0.4rem;
+  transition:
+    background 0.15s var(--ease-out-2),
+    color 0.15s var(--ease-out-2);
+}
+
+.theme-toggle:hover {
+  color: var(--text);
 }
 
 #main-nav {
@@ -71,7 +181,7 @@ header h1 {
 
 .nav-btn {
   background: var(--bg-surface);
-  border: 1px solid transparent;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
   cursor: pointer;
@@ -79,8 +189,9 @@ header h1 {
   min-height: 44px;
   padding: 0.5rem 1rem;
   transition:
-    background 0.15s,
-    color 0.15s;
+    background 0.15s var(--ease-out-2),
+    color 0.15s var(--ease-out-2),
+    box-shadow 0.15s var(--ease-out-2);
 }
 
 .nav-btn:hover {
@@ -89,6 +200,7 @@ header h1 {
 
 .nav-btn.active {
   background: var(--accent-bg);
+  border-color: var(--accent-bg);
   color: #fff;
 }
 
@@ -96,18 +208,20 @@ header h1 {
 
 .btn {
   background: var(--bg-surface);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text);
   cursor: pointer;
   font-size: 0.9rem;
   min-height: 44px;
   padding: 0.6rem 1.2rem;
-  transition: background 0.15s;
+  transition:
+    background 0.15s var(--ease-out-2),
+    box-shadow 0.15s var(--ease-out-2);
 }
 
 .btn:hover {
-  background: var(--bg-input);
+  box-shadow: var(--shadow-2);
 }
 
 .btn-primary {
@@ -143,11 +257,16 @@ header h1 {
 
 /* ---- Forms ---- */
 
-.log-form,
-.pin-form {
+.log-form {
   display: flex;
   flex-direction: column;
   gap: var(--gap);
+}
+
+.pin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .field-group {
@@ -159,6 +278,7 @@ header h1 {
 .field-group label {
   color: var(--text-muted);
   font-size: 0.8rem;
+  font-weight: 500;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -167,14 +287,14 @@ input,
 select,
 textarea {
   background: var(--bg-input);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text);
   font-family: inherit;
   font-size: 1rem;
   min-height: 44px;
   padding: 0.6rem 0.8rem;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s var(--ease-out-2);
 }
 
 input:focus,
@@ -198,8 +318,11 @@ textarea {
 
 .entry-item {
   background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
+  box-shadow: var(--shadow-2);
   padding: var(--gap);
+  transition: box-shadow 0.15s var(--ease-out-2);
 }
 
 .entry-summary {
@@ -214,32 +337,37 @@ textarea {
 }
 
 .entry-reason {
-  border-radius: 4px;
-  color: #fff;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.65rem;
   text-transform: uppercase;
 }
 
 .entry-reason--office {
-  background: #2d6a4f;
+  background: var(--badge-office-bg);
+  color: var(--badge-office);
 }
 
 .entry-reason--wfh {
-  background: #1d4e89;
+  background: var(--badge-wfh-bg);
+  color: var(--badge-wfh);
 }
 
 .entry-reason--leave {
-  background: #7b2d8b;
+  background: var(--badge-leave-bg);
+  color: var(--badge-leave);
 }
 
 .entry-reason--sick {
-  background: #9a5218;
+  background: var(--badge-sick-bg);
+  color: var(--badge-sick);
 }
 
 .entry-reason--public-holiday {
-  background: #6c757d;
+  background: var(--badge-holiday-bg);
+  color: var(--badge-holiday);
 }
 
 .entry-notes {
@@ -257,11 +385,18 @@ textarea {
 /* ---- Settings ---- */
 
 .settings-group {
-  margin-bottom: 1.5rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  margin-bottom: var(--gap);
+  padding: var(--gap);
 }
 
 .settings-group h3 {
-  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
 }
 
 .settings-group h4 {
@@ -272,7 +407,11 @@ textarea {
 .settings-group p {
   color: var(--text-muted);
   font-size: 0.9rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.settings-group-danger {
+  border-left: 3px solid var(--danger);
 }
 
 .warning {
@@ -290,7 +429,7 @@ textarea {
 }
 
 .pin-message-success {
-  color: #4caf7c;
+  color: var(--success);
 }
 
 .pin-strength {
@@ -305,11 +444,11 @@ textarea {
 }
 
 .pin-strength-fair {
-  color: #e6a23c;
+  color: var(--warning);
 }
 
 .pin-strength-strong {
-  color: #4caf7c;
+  color: var(--success);
 }
 
 /* ---- Empty state ---- */
@@ -325,18 +464,23 @@ textarea {
 
 h2 {
   font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
   margin-bottom: 1rem;
 }
 
 h3 {
   font-size: 1rem;
+  font-weight: 600;
 }
 
 /* ---- Attendance banner ---- */
 
 .attendance-banner {
   background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
+  box-shadow: var(--shadow-3);
   margin-bottom: var(--gap);
   padding: var(--gap);
   text-align: center;
@@ -349,17 +493,47 @@ h3 {
 }
 
 .attendance-ok {
-  color: #4caf7c;
+  color: var(--success);
 }
 
 .attendance-below {
   color: var(--accent);
 }
 
+.attendance-bar {
+  background: var(--bg-input);
+  border-radius: 4px;
+  height: 8px;
+  margin-top: 0.75rem;
+  overflow: visible;
+  position: relative;
+}
+
+.attendance-fill {
+  border-radius: 4px;
+  height: 100%;
+  transition: width 0.3s var(--ease-out-3);
+}
+
+.attendance-fill-ok {
+  background: var(--success);
+}
+
+.attendance-fill-below {
+  background: var(--accent);
+}
+
+.attendance-target {
+  border-left: 2px dashed var(--text-muted);
+  height: 14px;
+  position: absolute;
+  top: -3px;
+}
+
 .attendance-detail {
   color: var(--text-muted);
   font-size: 0.85rem;
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
 }
 
 /* ---- Attendance settings ---- */
@@ -435,6 +609,18 @@ h2[tabindex='-1']:focus {
   *::before,
   *::after {
     transition-duration: 0.01ms !important;
+  }
+}
+
+/* ---- Micro-interactions ---- */
+
+@media (prefers-reduced-motion: no-preference) {
+  .btn:active {
+    transform: scale(0.97);
+  }
+
+  .entry-item:hover {
+    box-shadow: var(--shadow-3);
   }
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,157 @@
+// Theme application: reads preference, applies to DOM, listens for OS changes.
+
+import type { ThemePreference } from './types'
+import { loadThemePreference, saveThemePreference } from './settings'
+
+const THEME_META_COLORS: Record<'light' | 'dark', string> = {
+  light: '#f4f5f7',
+  dark: '#1a1a2e',
+}
+
+const CYCLE_ORDER: ThemePreference[] = ['auto', 'light', 'dark']
+
+const LABELS: Record<ThemePreference, string> = {
+  auto: 'Auto',
+  light: 'Light',
+  dark: 'Dark',
+}
+
+let current: ThemePreference = 'auto'
+let toggleButton: HTMLButtonElement | null = null
+
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+// Resolve the effective theme (light or dark) from the current preference.
+const resolvedTheme = (): 'light' | 'dark' => {
+  if (current === 'auto') return mediaQuery.matches ? 'dark' : 'light'
+  return current
+}
+
+const applyTheme = (): void => {
+  document.documentElement.dataset.theme = current
+  const resolved = resolvedTheme()
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute('content', THEME_META_COLORS[resolved])
+}
+
+// Build an SVG element using the SVG namespace.
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+const svgEl = (
+  tag: string,
+  attrs: Record<string, string>,
+  ...children: SVGElement[]
+): SVGElement => {
+  const el = document.createElementNS(SVG_NS, tag)
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v)
+  for (const child of children) el.appendChild(child)
+  return el
+}
+
+// Sun icon: circle with rays.
+const sunIcon = (): SVGElement =>
+  svgEl(
+    'svg',
+    {
+      width: '18',
+      height: '18',
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      'stroke-width': '2',
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+    },
+    svgEl('circle', { cx: '12', cy: '12', r: '5' }),
+    svgEl('line', { x1: '12', y1: '1', x2: '12', y2: '3' }),
+    svgEl('line', { x1: '12', y1: '21', x2: '12', y2: '23' }),
+    svgEl('line', { x1: '4.22', y1: '4.22', x2: '5.64', y2: '5.64' }),
+    svgEl('line', { x1: '18.36', y1: '18.36', x2: '19.78', y2: '19.78' }),
+    svgEl('line', { x1: '1', y1: '12', x2: '3', y2: '12' }),
+    svgEl('line', { x1: '21', y1: '12', x2: '23', y2: '12' }),
+    svgEl('line', { x1: '4.22', y1: '19.78', x2: '5.64', y2: '18.36' }),
+    svgEl('line', { x1: '18.36', y1: '5.64', x2: '19.78', y2: '4.22' }),
+  )
+
+// Moon icon: crescent shape.
+const moonIcon = (): SVGElement =>
+  svgEl(
+    'svg',
+    {
+      width: '18',
+      height: '18',
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      'stroke-width': '2',
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+    },
+    svgEl('path', {
+      d: 'M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z',
+    }),
+  )
+
+// Auto icon: half-circle (split sun/moon).
+const autoIcon = (): SVGElement =>
+  svgEl(
+    'svg',
+    {
+      width: '18',
+      height: '18',
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      'stroke-width': '2',
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+    },
+    svgEl('circle', { cx: '12', cy: '12', r: '9' }),
+    svgEl('path', {
+      d: 'M12 3a9 9 0 0 1 0 18',
+      fill: 'currentColor',
+    }),
+  )
+
+const ICONS: Record<ThemePreference, () => SVGElement> = {
+  auto: autoIcon,
+  light: sunIcon,
+  dark: moonIcon,
+}
+
+const updateButtonLabel = (): void => {
+  if (!toggleButton) return
+  toggleButton.replaceChildren(ICONS[current]())
+  toggleButton.setAttribute(
+    'aria-label',
+    `Theme: ${LABELS[current]}. Click to change.`,
+  )
+}
+
+// Cycle through auto → light → dark → auto.
+const cycleTheme = async (): Promise<void> => {
+  const idx = CYCLE_ORDER.indexOf(current)
+  current = CYCLE_ORDER[(idx + 1) % CYCLE_ORDER.length]
+  applyTheme()
+  updateButtonLabel()
+  await saveThemePreference(current)
+}
+
+// Initialise the theme toggle button in the header.
+export const initThemeToggle = (button: HTMLButtonElement): void => {
+  toggleButton = button
+  updateButtonLabel()
+  button.addEventListener('click', () => {
+    cycleTheme()
+  })
+}
+
+// Load saved preference and apply. Call before first render.
+export const initTheme = async (): Promise<void> => {
+  current = await loadThemePreference()
+  applyTheme()
+
+  mediaQuery.addEventListener('change', () => {
+    if (current === 'auto') applyTheme()
+  })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,5 @@ export interface UnlockResult {
   retryAfterMs?: number
   wiped?: boolean
 }
+
+export type ThemePreference = 'auto' | 'light' | 'dark'

--- a/src/ui/danger.ts
+++ b/src/ui/danger.ts
@@ -33,7 +33,7 @@ export const buildDangerSection = (onDataWiped: () => void): HTMLElement => {
   }
 
   return html`
-    <div class="settings-group">
+    <div class="settings-group settings-group-danger">
       <h3>Danger zone</h3>
       <p>Permanently remove all data from this device.</p>
       <form class="pin-form" onsubmit=${onDelete}>

--- a/src/ui/log.ts
+++ b/src/ui/log.ts
@@ -20,6 +20,9 @@ const buildBanner = (
   weeks: number,
 ): HTMLElement => {
   const ok = percentage >= target
+  const fillClass = ok ? 'attendance-fill-ok' : 'attendance-fill-below'
+  // Cap at 100% for display.
+  const fillWidth = Math.min(percentage, 100)
   return html`
     <div
       class="attendance-banner"
@@ -32,6 +35,23 @@ const buildBanner = (
           : 'attendance-below'}"
       >
         ${percentage}%
+      </div>
+      <div
+        class="attendance-bar"
+        role="progressbar"
+        aria-valuenow=${percentage}
+        aria-valuemin=${0}
+        aria-valuemax=${100}
+      >
+        <div
+          class="attendance-fill ${fillClass}"
+          style="width: ${fillWidth}%"
+        ></div>
+        <div
+          class="attendance-target"
+          style="left: ${target}%"
+          aria-label="Target: ${target}%"
+        ></div>
       </div>
       <div class="attendance-detail">
         ${`${attended} of ${total} days in office (last ${weeks} weeks, target ${target}%)`}


### PR DESCRIPTION
Add a three-state theme system and refresh the visual design using Open Props design tokens.

## Theme system

- Three-state toggle in the header: auto (follows OS) → light → dark
- SVG sun/moon/half-circle icons built programmatically (CSP-safe, no innerHTML)
- Preference persisted in IndexedDB meta store
- Dynamic `<meta name="theme-color">` update per resolved theme
- `data-theme` attribute on `<html>` drives CSS custom property switching

## Visual refresh

- Import Open Props for shadows (`--shadow-1` to `--shadow-4`) and easings
- Dual-palette CSS custom properties: light defaults in `:root`, dark overrides in `[data-theme='dark']` and `@media (prefers-color-scheme: dark)` for auto mode
- Semantic colour tokens: `--success`, `--warning`, badge bg/fg pairs per attendance reason
- Card depth with `box-shadow` on entry items and settings groups
- Pill-shaped attendance badges with theme-adaptive colours
- Attendance progress bar with fill + dashed target marker
- Settings visual hierarchy: card treatment, danger zone red left border accent
- Micro-interactions: `scale(0.97)` on button press, shadow lift on card hover
- All animations gated behind `prefers-reduced-motion: no-preference`

## Files changed

- **New**: `src/theme.ts` - theme lifecycle (load, save, toggle, icons, OS listener)
- **Modified**: `src/types.ts`, `src/db.ts`, `src/settings.ts` - `ThemePreference` type + DB/mediator layer
- **Modified**: `src/main.ts` - bootstrap theme before first render
- **Modified**: `index.html` - `data-theme="auto"`, header layout with toggle button
- **Modified**: `src/style.css` - complete restyle with dual palettes and Open Props
- **Modified**: `src/ui/log.ts` - attendance progress bar
- **Modified**: `src/ui/danger.ts` - danger zone card class
- **Modified**: `package.json` - added `open-props` dependency