### PR TITLE
fix: use CSSOM for inline styles to avoid CSP violations

### DIFF
--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -24,6 +24,9 @@ const h = (
           key.slice(2).toLowerCase(),
           val as EventListener,
         )
+      } else if (key === 'style' && typeof val === 'string') {
+        // Use CSSOM to avoid CSP style-src violations.
+        element.style.cssText = val
       } else if (DOM_PROPERTIES.has(key)) {
         ;(element as unknown as Record<string, unknown>)[key] = val
       } else if (val !== false && val !== null && val !== undefined) {


### PR DESCRIPTION
Handle `style` attributes via `element.style.cssText` instead of `setAttribute` in the `h()` function.

Fixes `style-src 'self'` CSP errors on the attendance bar fill width and target marker position.